### PR TITLE
fix: can not run app on MacOS

### DIFF
--- a/macos/Classes/BlueThermalPrinterPlugin.h
+++ b/macos/Classes/BlueThermalPrinterPlugin.h
@@ -1,4 +1,4 @@
-#import <Flutter/Flutter.h>
+// #import <Flutter/Flutter.h>
 
-@interface DragoBluePrinterPlugin : NSObject<FlutterPlugin>
-@end
+// @interface DragoBluePrinterPlugin : NSObject<FlutterPlugin>
+// @end

--- a/macos/Classes/BlueThermalPrinterPlugin.m
+++ b/macos/Classes/BlueThermalPrinterPlugin.m
@@ -1,8 +1,8 @@
-#import "DragoBluePrinterPlugin.h"
-#import <drago_blue_printer/drago_blue_printer-Swift.h>
+// #import "DragoBluePrinterPlugin.h"
+// #import <drago_blue_printer/drago_blue_printer-Swift.h>
 
-@implementation DragoBluePrinterPlugin
-+ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftDragoBluePrinterPlugin registerWithRegistrar:registrar];
-}
-@end
+// @implementation DragoBluePrinterPlugin
+// + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+//   [SwiftDragoBluePrinterPlugin registerWithRegistrar:registrar];
+// }
+// @end

--- a/macos/Classes/SwiftBlueThermalPrinterPlugin.swift
+++ b/macos/Classes/SwiftBlueThermalPrinterPlugin.swift
@@ -1,14 +1,15 @@
-import Flutter
-import UIKit
+import FlutterMacOS
+import AppKit
 
-public class SwiftDragoBluePrinterPlugin: NSObject, FlutterPlugin {
+public class DragoBluePrinterPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "drago_blue_printer", binaryMessenger: registrar.messenger())
-    let instance = SwiftDragoBluePrinterPlugin()
+    let channel = FlutterMethodChannel(name: "drago_blue_printer", binaryMessenger: registrar.messenger)
+    let instance = DragoBluePrinterPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    result("iOS " + UIDevice.current.systemVersion)
+    // result("iOS " + UIDevice.current.systemVersion)
+    result(NSNumber(value: 0))
   }
 }

--- a/macos/drago_blue_printer.podspec
+++ b/macos/drago_blue_printer.podspec
@@ -13,8 +13,8 @@ A new Flutter plugin for connecting to thermal printer vie bluetooth
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Zaki Mubarok' => 'selvam@gmail.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*''
-  s.public_header_files = 'Classes/**/*.h''
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.13'
   s.framework = 'CoreBluetooth'


### PR DESCRIPTION
## Issue:
- After I install the package `drago_blue_printer` to my main app, it work well on Window OS. But when I run app on Mac OS, it doesn't work.

## Resolved:
- This PR help the main app which use package `drago_blue_printer` can run on Mac OS

## Restricted:
- Still not print on Mac OS, it just help main app run and build success.